### PR TITLE
Properly separate render state and improve mixins

### DIFF
--- a/common/src/main/java/com/yyz/yyzsbackpack/base/BackpackRenderState.java
+++ b/common/src/main/java/com/yyz/yyzsbackpack/base/BackpackRenderState.java
@@ -1,9 +1,14 @@
 package com.yyz.yyzsbackpack.base;
 
-import net.minecraft.world.entity.Avatar;
+import net.minecraft.resources.ResourceLocation;
 
 public interface BackpackRenderState {
-    void setAbstractClientPlayer(Avatar player);
+    boolean yyzsbackpack$shouldRender();
+    void yyzsbackpack$setShouldRender(boolean value);
 
-    Avatar getAbstractClientPlayer();
+    int yyzsbackpack$getDyeColor();
+    void yyzsbackpack$setDyeColor(int color);
+
+    ResourceLocation yyzsbackpack$getDetailedOverlayTexture();
+    void yyzsbackpack$setDetailedOverlayTexture(ResourceLocation location);
 }

--- a/common/src/main/java/com/yyz/yyzsbackpack/client/DetailedBackpackFeatureRenderer.java
+++ b/common/src/main/java/com/yyz/yyzsbackpack/client/DetailedBackpackFeatureRenderer.java
@@ -3,9 +3,7 @@ package com.yyz.yyzsbackpack.client;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.yyz.yyzsbackpack.Backpack;
-import com.yyz.yyzsbackpack.BackpackPlatform;
 import com.yyz.yyzsbackpack.base.BackpackRenderState;
-import com.yyz.yyzsbackpack.item.BackpackItem;
 import net.minecraft.client.model.PlayerModel;
 import net.minecraft.client.model.geom.ModelPart;
 import net.minecraft.client.model.geom.PartPose;
@@ -21,9 +19,7 @@ import net.minecraft.client.renderer.entity.state.AvatarRenderState;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.entity.Avatar;
-import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.item.component.DyedItemColor;
+import org.spongepowered.asm.mixin.Unique;
 
 
 public class DetailedBackpackFeatureRenderer extends RenderLayer<AvatarRenderState, PlayerModel> {
@@ -38,26 +34,24 @@ public class DetailedBackpackFeatureRenderer extends RenderLayer<AvatarRenderSta
         this.backpack_overlay =  createBackpackOverlayModel();
     }
 
-
     @Override
     public void submit(PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int i, AvatarRenderState entityRenderState, float f, float g) {
-        Avatar player = ((BackpackRenderState)entityRenderState).getAbstractClientPlayer();
-        if (shouldRender(player)) {
+        if (((BackpackRenderState) entityRenderState).yyzsbackpack$shouldRender()) {
 
-            int j = DyedItemColor.getOrDefault(BackpackPlatform.getEquippedL(player), -6265536);
+            int j = ((BackpackRenderState) entityRenderState).yyzsbackpack$getDyeColor();
 
             poseStack.pushPose();
             this.getParentModel().body.translateAndRotate(poseStack);
             poseStack.scale(0.8f, 0.8f, 0.8f);
             submitNodeCollector.submitModelPart(backpack,poseStack,RenderType.entitySolid(getTexture()),i, OverlayTexture.NO_OVERLAY,(TextureAtlasSprite)null,j,null);
-            submitNodeCollector.submitModelPart(backpack_overlay,poseStack,RenderType.entitySolid(getOverlayTexture(player)),i, OverlayTexture.NO_OVERLAY,(TextureAtlasSprite)null);
+            submitNodeCollector.submitModelPart(backpack_overlay,poseStack,RenderType.entitySolid(((BackpackRenderState) entityRenderState).yyzsbackpack$getDetailedOverlayTexture()),i, OverlayTexture.NO_OVERLAY,(TextureAtlasSprite)null);
 
             poseStack.popPose();
         }
 
     }
 
-
+    @Unique
     private ModelPart createBackpackModel() {
         MeshDefinition meshdefinition = new MeshDefinition();
         PartDefinition partdefinition = meshdefinition.getRoot();
@@ -77,6 +71,7 @@ public class DetailedBackpackFeatureRenderer extends RenderLayer<AvatarRenderSta
         return meshdefinition.getRoot().bake(64, 64).getChild("backpack");
     }
 
+    @Unique
     private ModelPart createBackpackOverlayModel() {
         MeshDefinition meshdefinition = new MeshDefinition();
         PartDefinition partdefinition = meshdefinition.getRoot();
@@ -86,20 +81,9 @@ public class DetailedBackpackFeatureRenderer extends RenderLayer<AvatarRenderSta
         return meshdefinition.getRoot().bake(64, 64).getChild("backpack_overlay");
     }
 
-
-
-    private boolean shouldRender(Avatar player) {
-        return BackpackPlatform.getEquippedL(player).getItem() instanceof BackpackItem && Backpack.getConfig().render_backpack_model && Backpack.getConfig().backpack_model_style.equals("detailed");
-    }
+    @Unique
     private ResourceLocation getTexture() {
         return ResourceLocation.fromNamespaceAndPath(Backpack.MOD_ID, "textures/backpack/backpack.png");
     }
-    private ResourceLocation getOverlayTexture(LivingEntity player) {
-        if(BackpackPlatform.getEquippedL(player).getItem() instanceof BackpackItem backpackItem){
-            return backpackItem.getBackpackType().getModelTexture();
-        }
-        return ResourceLocation.fromNamespaceAndPath(Backpack.MOD_ID, "textures/backpack/gold_backpack.png");
-    }
-
 
 }

--- a/common/src/main/java/com/yyz/yyzsbackpack/client/SimplifiedBackpackFeatureRenderer.java
+++ b/common/src/main/java/com/yyz/yyzsbackpack/client/SimplifiedBackpackFeatureRenderer.java
@@ -62,10 +62,8 @@ public class SimplifiedBackpackFeatureRenderer extends RenderLayer<AvatarRenderS
     }
     @Override
     public void submit(PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int i, AvatarRenderState entityRenderState, float f, float g) {
-        Avatar player = ((BackpackRenderState)entityRenderState).getAbstractClientPlayer();
-        if (shouldRender(player)) {
-
-            int j = DyedItemColor.getOrDefault(BackpackPlatform.getEquippedL(player), -6265536);
+        if (((BackpackRenderState) entityRenderState).yyzsbackpack$shouldRender()) {
+            int j = ((BackpackRenderState) entityRenderState).yyzsbackpack$getDyeColor();
 
             poseStack.pushPose();
             this.getParentModel().body.translateAndRotate(poseStack);

--- a/common/src/main/java/com/yyz/yyzsbackpack/mixin/PlayerRenderStateMixin.java
+++ b/common/src/main/java/com/yyz/yyzsbackpack/mixin/PlayerRenderStateMixin.java
@@ -2,21 +2,43 @@ package com.yyz.yyzsbackpack.mixin;
 
 import com.yyz.yyzsbackpack.base.BackpackRenderState;
 import net.minecraft.client.renderer.entity.state.AvatarRenderState;
-import net.minecraft.world.entity.Avatar;
+import net.minecraft.resources.ResourceLocation;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
 @Mixin(AvatarRenderState.class)
 public class PlayerRenderStateMixin implements BackpackRenderState {
-    @Unique
-    private Avatar player;
+    @Unique private int yyzsbackpack$dyeColor = -6265536;
+    @Unique private boolean yyzsbackpack$shouldRender;
+    @Unique private ResourceLocation yyzsbackpack$detailedOverlayTexture;
+
     @Override
-    public void setAbstractClientPlayer(Avatar player) {
-        this.player = player;
+    public boolean yyzsbackpack$shouldRender() {
+        return this.yyzsbackpack$shouldRender;
     }
 
     @Override
-    public Avatar getAbstractClientPlayer() {
-        return this.player;
+    public void yyzsbackpack$setShouldRender(boolean value) {
+        this.yyzsbackpack$shouldRender = value;
+    }
+
+    @Override
+    public int yyzsbackpack$getDyeColor() {
+        return this.yyzsbackpack$dyeColor;
+    }
+
+    @Override
+    public void yyzsbackpack$setDyeColor(int color) {
+        this.yyzsbackpack$dyeColor = color;
+    }
+
+    @Override
+    public ResourceLocation yyzsbackpack$getDetailedOverlayTexture() {
+        return this.yyzsbackpack$detailedOverlayTexture;
+    }
+
+    @Override
+    public void yyzsbackpack$setDetailedOverlayTexture(ResourceLocation location) {
+        this.yyzsbackpack$detailedOverlayTexture = location;
     }
 }

--- a/common/src/main/java/com/yyz/yyzsbackpack/mixin/PlayerRendererMixin.java
+++ b/common/src/main/java/com/yyz/yyzsbackpack/mixin/PlayerRendererMixin.java
@@ -1,16 +1,23 @@
 package com.yyz.yyzsbackpack.mixin;
 
+import com.yyz.yyzsbackpack.Backpack;
+import com.yyz.yyzsbackpack.BackpackPlatform;
 import com.yyz.yyzsbackpack.base.BackpackRenderState;
 import com.yyz.yyzsbackpack.client.DetailedBackpackFeatureRenderer;
 import com.yyz.yyzsbackpack.client.SimplifiedBackpackFeatureRenderer;
+import com.yyz.yyzsbackpack.item.BackpackItem;
 import net.minecraft.client.entity.ClientAvatarEntity;
 import net.minecraft.client.model.PlayerModel;
 import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.client.renderer.entity.player.AvatarRenderer;
 import net.minecraft.client.renderer.entity.state.AvatarRenderState;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Avatar;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.component.DyedItemColor;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -38,6 +45,23 @@ public abstract class PlayerRendererMixin<AvatarlikeEntity extends Avatar & Clie
             at = @At("RETURN")
     )
     private void injectExtractRenderState(AvatarlikeEntity avatar, AvatarRenderState avatarRenderState, float f, CallbackInfo ci) {
-        ((BackpackRenderState)avatarRenderState).setAbstractClientPlayer(avatar);
+        if (avatar != null) {
+            ((BackpackRenderState) avatarRenderState).yyzsbackpack$setShouldRender(shouldRender(avatar));
+            ((BackpackRenderState) avatarRenderState).yyzsbackpack$setDyeColor(DyedItemColor.getOrDefault(BackpackPlatform.getEquippedL(avatar), -6265536));
+            ((BackpackRenderState) avatarRenderState).yyzsbackpack$setDetailedOverlayTexture(getOverlayTexture(avatar));
+        }
+    }
+
+    @Unique
+    private static boolean shouldRender(Avatar player) {
+        return BackpackPlatform.getEquippedL(player).getItem() instanceof BackpackItem && Backpack.getConfig().render_backpack_model && Backpack.getConfig().backpack_model_style.equals("detailed");
+    }
+
+    @Unique
+    private ResourceLocation getOverlayTexture(LivingEntity player) {
+        if(BackpackPlatform.getEquippedL(player).getItem() instanceof BackpackItem backpackItem){
+            return backpackItem.getBackpackType().getModelTexture();
+        }
+        return ResourceLocation.fromNamespaceAndPath(Backpack.MOD_ID, "textures/backpack/gold_backpack.png");
     }
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -34,5 +34,6 @@
   },
   "suggests": {
     "another-mod": "*"
-  }
+  },
+  "accessWidener": "yyzsbackpack.accesswidener"
 }


### PR DESCRIPTION
Also fixes a random multiplayer crash that occurs with backpacks. Not sure why it occurred, but passing the player directly into the render state was definitely a cause.

For future reference:
- All new fields and methods added into mixins must be prefixed to avoid mod compatibility issues (unless marked with `@Unique`, but you cannot mark `@Unique` for methods that are injected via interfaces.)
- The render state is separated like this specifically so you can pass data between the client thread and the render thread. While they are currently on the same thread, that may very well not be the case for other mods, which can introduce many race conditions such as this one.